### PR TITLE
setup and cleanup bench functions

### DIFF
--- a/gd-rehearse-defs/Cargo.toml
+++ b/gd-rehearse-defs/Cargo.toml
@@ -10,5 +10,8 @@ license = "MPL-2.0"
 godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
 paste = "1.0.14"
 
+[dev-dependencies]
+gd-rehearse = { path = "../gd-rehearse" }
+
 [package.metadata.docs.rs]
 license-file = "../License.txt"

--- a/gd-rehearse-defs/src/cases/rust_test_case.rs
+++ b/gd-rehearse-defs/src/cases/rust_test_case.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
+use godot::engine::Node;
+use godot::obj::Gd;
+
 use super::{Case, CaseContext};
 
 /// Rust test case.
@@ -21,7 +24,7 @@ pub struct RustTestCase {
     pub scene_path: Option<&'static str>,
     #[allow(dead_code)]
     pub line: u32,
-    pub function: fn(&CaseContext),
+    pub function: fn(&TestContext),
 }
 
 impl Case for RustTestCase {
@@ -45,5 +48,24 @@ impl Case for RustTestCase {
     }
     fn get_case_line(&self) -> u32 {
         self.line
+    }
+}
+
+/// Optional test context for `#[gditest]`.
+///
+/// Allows accessing [GdTestRunner](crate::runner::GdTestRunner) scene tree during tests.
+pub struct TestContext {
+    pub(crate) scene_tree: Gd<Node>,
+}
+
+impl TestContext {
+    pub(crate) fn new(scene_tree: Gd<Node>) -> Self {
+        Self { scene_tree }
+    }
+}
+
+impl CaseContext for TestContext {
+    fn scene_tree(&self) -> &Gd<Node> {
+        &self.scene_tree
     }
 }

--- a/gd-rehearse-defs/src/runner/config.rs
+++ b/gd-rehearse-defs/src/runner/config.rs
@@ -39,7 +39,7 @@ pub(crate) struct CliConfig {
     only_scene_path: bool,
     keyword: String,
     filters: Vec<String>,
-    quiet_run: bool
+    quiet_run: bool,
 }
 
 impl CliConfig {
@@ -134,7 +134,7 @@ impl CliConfig {
             only_scene_path,
             keyword,
             filters,
-            quiet_run
+            quiet_run,
         })
     }
 
@@ -261,7 +261,7 @@ impl RunnerConfig {
         only_scene_path: bool,
         scene_path: String,
         filters: &PackedStringArray,
-        quiet_run: bool
+        quiet_run: bool,
     ) -> Result<Self, ConfigError> {
         let keyword = keyword.to_string();
         let filters = filters
@@ -280,7 +280,7 @@ impl RunnerConfig {
             only_scene_path,
             scene_path,
             filters,
-            quiet_run
+            quiet_run,
         };
 
         if !is_headless_run() {
@@ -335,7 +335,7 @@ pub(crate) struct RunnerInfo {
     pub mode: &'static str,
     pub rust_build: &'static str,
     pub godot_build: &'static str,
-    pub additional_message: Vec<String>
+    pub additional_message: Vec<String>,
 }
 
 impl RunnerInfo {
@@ -346,17 +346,9 @@ impl RunnerInfo {
             "EDITOR"
         };
 
-        let rust_build = if is_rust_debug() {
-            "debug"
-        } else {
-            "release"
-        };
+        let rust_build = if is_rust_debug() { "debug" } else { "release" };
 
-        let godot_build = if is_godot_debug() {
-            "debug"
-        } else {
-            "release"
-        };
+        let godot_build = if is_godot_debug() { "debug" } else { "release" };
 
         let mut additional_message = Vec::new();
         if !config.keyword().is_empty() {
@@ -375,6 +367,11 @@ impl RunnerInfo {
             additional_message.push("scene path specific".to_owned())
         }
 
-        Self { mode, rust_build, godot_build, additional_message }
+        Self {
+            mode,
+            rust_build,
+            godot_build,
+            additional_message,
+        }
     }
 }

--- a/gd-rehearse-defs/src/runner/print.rs
+++ b/gd-rehearse-defs/src/runner/print.rs
@@ -71,12 +71,19 @@ impl MessageWriter {
     }
 
     pub fn print_summary_info(&self, config: &RunnerConfig) {
-
-        let RunnerInfo { mode, rust_build, godot_build, additional_message } = RunnerInfo::gather(config);
+        let RunnerInfo {
+            mode,
+            rust_build,
+            godot_build,
+            additional_message,
+        } = RunnerInfo::gather(config);
 
         self.println(&format!(
             "{:^80}",
-            format!("Began run in {mode} mode in scene: {scene_path}", scene_path = &config.scene_path())
+            format!(
+                "Began run in {mode} mode in scene: {scene_path}",
+                scene_path = &config.scene_path()
+            )
         ));
 
         self.println(&format!(

--- a/gd-rehearse-macros/src/itest.rs
+++ b/gd-rehearse-macros/src/itest.rs
@@ -82,7 +82,7 @@ pub fn attribute_gditest(input_decl: Declaration) -> Result<TokenStream, Error> 
                 .ty
                 .tokens
                 .last()
-                .map(|last| last.to_string() == "CaseContext")
+                .map(|last| last.to_string() == "TestContext")
                 .unwrap_or(false);
             if is_context {
                 param.to_token_stream()
@@ -93,7 +93,7 @@ pub fn attribute_gditest(input_decl: Declaration) -> Result<TokenStream, Error> 
             return bad_signature(&func);
         }
     } else {
-        quote! { __unused_context: &::gd_rehearse::CaseContext }
+        quote! { __unused_context: &::gd_rehearse::itest::TestContext }
     };
 
     let body = &func.body;
@@ -121,7 +121,7 @@ fn bad_signature(func: &Function) -> Result<TokenStream, Error> {
         func,
         "#[gditest] function must have one of these signatures:\
         \n  fn {f}() {{ ... }}\
-        \n  fn {f}(ctx: &CaseContext) {{ ... }}",
+        \n  fn {f}(ctx: &TestContext) {{ ... }}",
         f = func.name,
     )
 }

--- a/gd-rehearse-macros/src/lib.rs
+++ b/gd-rehearse-macros/src/lib.rs
@@ -21,7 +21,7 @@ mod utils;
 ///
 /// A function annotated with `#[gditest]` needs to:
 /// - Have no return values.
-/// - Have no parameters or only a singular [`CaseContext`](gd_rehearse_defs::cases::CaseContext).
+/// - Have no parameters or only a singular [`TestContext`](gd_rehearse_defs::cases::rust_test_case::TestContext).
 ///
 /// ## Attributes
 /// An attribute-less macro will make the tests run, but some attributes are available for better customizability, especially when working
@@ -34,7 +34,6 @@ mod utils;
 ///
 /// ## Examples
 /// ```no_run
-/// use gd_rehearse::CaseContext;
 /// use gd_rehearse::itest::*;
 ///
 /// // Causes a focus run during which only the focused tests will be executed, but only with
@@ -53,13 +52,13 @@ mod utils;
 ///
 /// // Can access the `GdTestRunner` scene_tree.
 /// #[gditest]
-/// fn test_with_ctx(ctx: &CaseContext) {
+/// fn test_with_ctx(ctx: &TestContext) {
 ///     ctx.scene_tree().instance_id();
 /// }
 ///
 /// // Will only run in `res://special_cases.tscn` scene.
 /// #[gditest(scene_path="res://special_cases.tscn")]
-/// fn test_with_path(ctx: &CaseContext) {
+/// fn test_with_path(ctx: &TestContext) {
 ///     let test_node = ctx.scene_tree().get_node("SomeTestNode".into());
 ///     assert!(test_node.is_some());
 ///     assert!(!test_node.unwrap().get("property_should_be_here".into()).is_nil());
@@ -77,7 +76,7 @@ pub fn gditest(meta: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// A function annotated with `#[gdbench]` must:
 /// - Have a return value.
-/// - Have no parameters or only a singular [`CaseContext`](gd_rehearse_defs::cases::CaseContext).
+/// - Have no parameters or only a singular [`BenchContext`](gd_rehearse_defs::cases::rust_bench::BenchContext).
 ///
 /// Every benchmark is executed 200 times for a *warm-up*, followed by 501 additional runs to assess runtime (an odd number of runs for easy
 /// median extraction). Minimum and median run times will be displayed.
@@ -91,13 +90,14 @@ pub fn gditest(meta: TokenStream, input: TokenStream) -> TokenStream {
 /// - `keyword`: A specific keyword that will be picked up by the runner. The benchmark runs only if the runner has the same keyword specified.
 /// - `scene_path`: Godot path to the scene. If specified, given benchmark will only run if runner's scene path is the same.
 /// - `repeat`: Specifies the number of internal repeats the benchmark should undergo. By default, the function executes 100 times within every run.
+/// - `setup`: Optional function that will be executed before benchmark execution, to set up the scene for benchmarks.
+/// - `cleanup`: Optional function that will be executed after benchmark execution, to clean up after benchmarks. Rarely needed, as when
+///   `setup` is present, the default cleanup function should always clean up efficiently.
 ///
 /// ## Examples
 /// ```no_run
-/// use gd_rehearse::CaseContext;
 /// use gd_rehearse::bench::*;
-/// use godot::obj::InstanceId;
-/// use godot::builtin::Variant;
+/// use godot::prelude::*;
 ///
 /// // Causes a focus run during which only the focused benchmarks will be executed, but only with
 /// // `my bench` as a keyword in the runner.
@@ -114,18 +114,18 @@ pub fn gditest(meta: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// // Can access the `GdTestRunner` scene_tree.
 /// #[gdbench]
-/// fn bench_with_ctx(ctx: &CaseContext) -> InstanceId {
+/// fn bench_with_ctx(ctx: &BenchContext) -> InstanceId {
 ///     ctx.scene_tree().instance_id()
 /// }
-/// 
+///
 /// // Will only run in `res://special_cases.tscn` scene.
 /// #[gdbench(scene_path="res://special_cases.tscn")]
-/// fn bench_with_path(ctx: &CaseContext) -> Variant {
+/// fn bench_with_path(ctx: &BenchContext) -> Variant {
 ///     let test_node = ctx.scene_tree().get_node("SomeTestNode".into()).expect("Can't get node");
 ///     let variant = test_node.get("property_should_be_here".into());
 ///     assert!(!variant.is_nil());
 ///     variant
-/// } 
+/// }
 /// ```
 #[proc_macro_attribute]
 pub fn gdbench(meta: TokenStream, input: TokenStream) -> TokenStream {

--- a/gd-rehearse-macros/src/parser.rs
+++ b/gd-rehearse-macros/src/parser.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
-use proc_macro2::{Literal, TokenTree};
+use proc_macro2::{Ident, Literal, TokenTree};
 use std::collections::VecDeque;
 use venial::{Attribute, AttributeValue};
 
@@ -19,6 +19,8 @@ pub enum AttributeIdent {
     Skip,
     Keyword,
     ScenePath,
+    Setup,
+    Cleanup,
 }
 
 impl AttributeIdent {
@@ -29,6 +31,8 @@ impl AttributeIdent {
             "skip" => Some(Self::Skip),
             "keyword" => Some(Self::Keyword),
             "scene_path" => Some(Self::ScenePath),
+            "setup" => Some(Self::Setup),
+            "cleanup" => Some(Self::Cleanup),
             _ => None,
         }
     }
@@ -40,6 +44,8 @@ impl AttributeIdent {
             AttributeIdent::Skip => "skip".to_owned(),
             AttributeIdent::Keyword => "keyword".to_owned(),
             AttributeIdent::ScenePath => "scene_path".to_owned(),
+            AttributeIdent::Setup => "setup".to_owned(),
+            AttributeIdent::Cleanup => "cleanup".to_owned(),
         }
     }
 
@@ -106,6 +112,16 @@ impl AttributeValueParser {
             return Err(venial::Error::new_at_tokens(token, "expected literal"));
         }
         Err(venial::Error::new("expected literal"))
+    }
+
+    pub fn get_ident(&mut self) -> Result<Ident, venial::Error> {
+        if let Some(token) = self.tokens.pop_front() {
+            if let TokenTree::Ident(ident) = token {
+                return Ok(ident);
+            }
+            return Err(venial::Error::new_at_tokens(token, "expected identifier"));
+        }
+        Err(venial::Error::new("expected identifier"))
     }
 
     pub fn from_attribute_group_at_path(

--- a/gd-rehearse/src/lib.rs
+++ b/gd-rehearse/src/lib.rs
@@ -11,19 +11,20 @@
 //! your code, and the crate provides the [`GdTestRunner`] [`GodotClass`](trait@godot::prelude::GodotClass) for executing them within
 //! a Godot scene.
 
-pub use gd_rehearse_defs::cases::CaseContext;
 pub use gd_rehearse_defs::runner::GdTestRunner;
 
 /// Contains all symbols necessary to use [`#[gditest]`](macro@gd_rehearse_macros::gditest) macro.
 pub mod itest {
-    pub use gd_rehearse_defs::cases::rust_test_case::RustTestCase;
+    pub use gd_rehearse_defs::cases::rust_test_case::{RustTestCase, TestContext};
+    pub use gd_rehearse_defs::cases::CaseContext;
     pub use gd_rehearse_defs::registry::itest::*;
     pub use gd_rehearse_macros::gditest;
 }
 
 /// Contains all symbols necessary to use [`#[gdbench]`](macro@gd_rehearse_macros::gdbench) macro.
 pub mod bench {
-    pub use gd_rehearse_defs::cases::rust_bench::{bench_used, RustBenchmark};
+    pub use gd_rehearse_defs::cases::rust_bench::{bench_used, BenchContext, RustBenchmark};
+    pub use gd_rehearse_defs::cases::CaseContext;
     pub use gd_rehearse_defs::registry::bench::*;
     pub use gd_rehearse_macros::gdbench;
 }

--- a/tests/rust/src/bench.rs
+++ b/tests/rust/src/bench.rs
@@ -1,8 +1,9 @@
 use gd_rehearse::bench::*;
-use gd_rehearse::CaseContext;
+use godot::engine::Node;
 use godot::engine::Object;
 use godot::obj::Gd;
 use godot::obj::InstanceId;
+use godot::obj::NewAlloc;
 
 #[gdbench(focus)]
 fn focused_bench() -> i32 {
@@ -20,7 +21,7 @@ fn normal_bench() -> i32 {
 }
 
 #[gdbench(keyword = "with ctx")]
-fn bench_with_ctx(ctx: &CaseContext) -> InstanceId {
+fn bench_with_ctx(ctx: &BenchContext) -> InstanceId {
     let gd: Gd<Object> = ctx.scene_tree().clone().upcast();
     gd.instance_id()
 }
@@ -35,4 +36,30 @@ fn shouldnt_run_path() -> i8 {
     let test = 1 + 1;
     assert_eq!(test, 1);
     test
+}
+
+fn setup_function(ctx: &mut BenchContext) {
+    let mut node = Node::new_alloc();
+    let mut child = Node::new_alloc();
+    child.set_name("SetupChild".into());
+    node.add_child(child);
+
+    ctx.setup_add_node(node, "SetupTest");
+}
+
+fn cleanup_function(ctx: &mut BenchContext) {
+    ctx.remove_added_node("SetupTest");
+}
+
+#[gdbench(setup=setup_function)]
+fn with_setup(ctx: &BenchContext) -> bool {
+    let _setup = ctx.get_setup_node("SetupTest");
+    let _child = ctx.get_node("SetupTest/SetupChild");
+    true
+}
+
+#[gdbench(setup=setup_function, cleanup=cleanup_function)]
+fn with_setup_and_cleanup(ctx: &BenchContext) -> bool {
+    let _setup = ctx.get_setup_node("SetupTest");
+    true
 }

--- a/tests/rust/src/itest.rs
+++ b/tests/rust/src/itest.rs
@@ -5,7 +5,6 @@
 */
 
 use gd_rehearse::itest::*;
-use gd_rehearse::CaseContext;
 use godot::engine::Object;
 use godot::obj::Gd;
 
@@ -31,7 +30,7 @@ fn skipped_test() {
 }
 
 #[gditest(keyword = "with ctx")]
-fn test_with_ctx(ctx: &CaseContext) {
+fn test_with_ctx(ctx: &TestContext) {
     let gd: Gd<Object> = ctx.scene_tree().clone().upcast();
     gd.instance_id();
 }
@@ -46,7 +45,7 @@ fn filter_me() {}
 fn filter_me_too() {}
 
 #[gditest(scene_path = "res://with_path.tscn")]
-fn with_test_path(ctx: &CaseContext) {
+fn with_test_path(ctx: &TestContext) {
     assert_eq!(
         ctx.scene_tree().get_scene_file_path().to_string(),
         "res://with_path.tscn"
@@ -60,7 +59,7 @@ fn shouldnt_run_path() {
 }
 
 #[gditest(scene_path = "res://with_path.tscn")]
-fn access_ctx_with_path(ctx: &CaseContext) {
+fn access_ctx_with_path(ctx: &TestContext) {
     let some_node = ctx.scene_tree().get_node("SomeNode".into());
     assert!(some_node.is_some());
 


### PR DESCRIPTION
Closes #1 

Additions of `setup` and `cleanup` attributes to `#[gdbenchj]` macro, allowing to use setup and cleanup functions before beginning the runs. Intended for setting up some data, that should be available during each run, without needing to set it up inside benchmark itself on every repetition.

https://github.com/StatisMike/gd-rehearse/commit/ab2a85d23b0be32ea0fd4508e8fea8c62e01b6c7#diff-212ba77d5182246abdda069cba5f8f742741e3ce8f69b2b0d998ff455fdb17c4R41-R65

Out of necessity `CaseContext` have been remade into a trait with some common functionality between renamed `TestContext` (for `#[gditest]`) and `BenchContext` (for `#[gdbench]`).