### PR TITLE
update gdext to 0.3.1

### DIFF
--- a/gd-rehearse-defs/Cargo.toml
+++ b/gd-rehearse-defs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-godot = { version = "^0.2.4" }
+godot = { version = "^0.3.1" }
 paste = { version = "^1.0.14" }
 
 [dev-dependencies]
@@ -15,3 +15,4 @@ gd-rehearse = { path = "../gd-rehearse" }
 
 [package.metadata.docs.rs]
 license-file = "../License.txt"
+

--- a/gd-rehearse-defs/src/registry/bench.rs
+++ b/gd-rehearse-defs/src/registry/bench.rs
@@ -57,7 +57,7 @@ impl GdBenchmarks {
     }
 
     fn get_benchmark_from_registry() -> Option<RustBenchmark> {
-        __godot_rust_plugin_GD_REHEARSE_RUST_BENCHMARKS
+        GD_REHEARSE_RUST_BENCHMARKS
             .lock()
             .expect("couldn't retrieve RustBenchmark")
             .pop()

--- a/gd-rehearse-defs/src/registry/itest.rs
+++ b/gd-rehearse-defs/src/registry/itest.rs
@@ -54,7 +54,7 @@ impl GdRustItests {
     }
 
     fn get_rust_case() -> Option<RustTestCase> {
-        __godot_rust_plugin_GD_REHEARSE_RUST_TEST_CASES
+        GD_REHEARSE_RUST_TEST_CASES
             .lock()
             .expect("can't retrieve RustTestCase")
             .pop()

--- a/gd-rehearse-macros/Cargo.toml
+++ b/gd-rehearse-macros/Cargo.toml
@@ -8,14 +8,15 @@ license = "MPL-2.0"
 proc-macro = true
 
 [dev-dependencies]
-gd-rehearse = { path="../gd-rehearse" }
-godot = { version = "^0.2.4" }
+gd-rehearse = { path = "../gd-rehearse" }
+godot = { version = "^0.3.1" }
 
 [dependencies]
-gd-rehearse-defs = { path="../gd-rehearse-defs" }
+gd-rehearse-defs = { path = "../gd-rehearse-defs" }
 proc-macro2 = "^1.0.63"
 quote = "^1.0.29"
 venial = "^0.5"
 
 [package.metadata.docs.rs]
 license-file = "../License.txt"
+

--- a/gd-rehearse-macros/src/bench.rs
+++ b/gd-rehearse-macros/src/bench.rs
@@ -158,7 +158,7 @@ pub fn attribute_bench(input_decl: Declaration) -> Result<TokenStream, venial::E
             }
         }
 
-        ::godot::sys::plugin_add!{GD_REHEARSE_RUST_BENCHMARKS in gd_rehearse::bench; ::gd_rehearse::bench::RustBenchmark {
+        ::godot::sys::plugin_add!{GD_REHEARSE_RUST_BENCHMARKS; ::gd_rehearse::bench::RustBenchmark {
           name: #bench_name_str,
           focused: #focused,
           skipped: #skipped,

--- a/gd-rehearse-macros/src/itest.rs
+++ b/gd-rehearse-macros/src/itest.rs
@@ -103,7 +103,7 @@ pub fn attribute_gditest(input_decl: Declaration) -> Result<TokenStream, Error> 
             #body
         }
 
-        ::godot::sys::plugin_add!(GD_REHEARSE_RUST_TEST_CASES in gd_rehearse::itest; ::gd_rehearse::itest::RustTestCase {
+        ::godot::sys::plugin_add!(GD_REHEARSE_RUST_TEST_CASES; ::gd_rehearse::itest::RustTestCase {
             name: #test_name_str,
             skipped: #skipped,
             focused: #focused,

--- a/gd-rehearse/Cargo.toml
+++ b/gd-rehearse/Cargo.toml
@@ -3,16 +3,17 @@ name = "gd-rehearse"
 version = "0.2.0"
 edition = "2021"
 license = "MPL-2.0"
-keywords = ["gamedev", "godot", "engine", "integration","test"]
+keywords = ["gamedev", "godot", "engine", "integration", "test"]
 categories = ["game-engines", "graphics", "test"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gd-rehearse-macros = { path = "../gd-rehearse-macros"}
-gd-rehearse-defs = { path = "../gd-rehearse-defs"}
+gd-rehearse-macros = { path = "../gd-rehearse-macros" }
+gd-rehearse-defs = { path = "../gd-rehearse-defs" }
 # For direct link in documentation
-godot = { version = "^0.2.4" }
+godot = { version = "^0.3.1" }
 
 [package.metadata.docs.rs]
 license-file = "../License.txt"
+

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -9,8 +9,9 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-godot = { version = "^0.2.4" }
+godot = { version = "^0.3.1" }
 gd-rehearse = { path = "../../gd-rehearse" }
 
 [package.metadata.docs.rs]
 license-file = "../License.txt"
+


### PR DESCRIPTION
Fix 'plugin_add!' macro calls.

I can try to make any other changes if need be!

I still can't get the GdTestRunner node to show up in my project, but the test project in gd-rehearse still runs and passes tests so... not sure what I'm doing wrong there.